### PR TITLE
ci(smoke)!: harden Java8+Gradle6.9.4, prove override, summary+retention

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,4 @@
-# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE VERIFY BEGIN
+# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE HARDEN BEGIN
 name: Smoke
 
 on:
@@ -37,18 +37,13 @@ jobs:
       - name: Gradle wrapper permissions
         run: chmod +x ./gradlew
 
-      - name: Show pinned gradle.properties (if any)
+      - name: Assert wrapper distributionUrl contains 6.9.4
         run: |
           set -eux
-          if [ -f gradle.properties ]; then
-            echo "----- gradle.properties -----"
-            sed -n '1,200p' gradle.properties | sed 's/./&/g' | cat
-            echo "-----------------------------"
-          else
-            echo "No root gradle.properties found."
-          fi
+          cat gradle/wrapper/gradle-wrapper.properties
+          grep -E "distributionUrl=.*6\.9\.4" gradle/wrapper/gradle-wrapper.properties
 
-      - name: Create CI init script to print JVMs and properties
+      - name: Create CI init script to prove JVM & props
         run: |
           cat > ci-init.gradle <<'EOF'
           println "[CI] env JAVA_HOME=" + System.getenv("JAVA_HOME")
@@ -81,10 +76,11 @@ jobs:
             [ -f "$f" ] && sha256sum "$f" || true
           done
 
-      - name: Upload smoke artifacts
+      - name: Upload smoke artifacts (7-day retention)
         uses: actions/upload-artifact@v4
         with:
           name: smoke-artifacts
+          retention-days: 7
           path: |
             ci-init.gradle
             gradle-version.txt
@@ -98,4 +94,24 @@ jobs:
             mapper-cli/build/smoke/remap-asm-b.jar
             mapper-cli/build/smoke/metrics1.json
             mapper-cli/build/smoke/metrics2.json
-# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE VERIFY END
+
+      - name: Job summary
+        run: |
+          {
+            echo "## BytecodeMapper Smoke"
+            echo ""
+            echo "- Java: \`$(java -version 2>&1 | head -n1)\`"
+            echo "- Gradle:"; head -n1 gradle-version.txt
+            echo "- Wrapper:"; grep distributionUrl gradle/wrapper/gradle-wrapper.properties | sed 's/^/- /'
+            echo ""
+            echo "Hashes (pairs should match):"
+            for f in mapper-cli/build/smoke/m1.tiny mapper-cli/build/smoke/m2.tiny \
+                     mapper-cli/build/smoke/remap-tiny-a.jar mapper-cli/build/smoke/remap-tiny-b.jar \
+                     mapper-cli/build/smoke/remap-asm-a.jar mapper-cli/build/smoke/remap-asm-b.jar \
+                     mapper-cli/build/smoke/metrics1.json mapper-cli/build/smoke/metrics2.json; do
+              if [ -f "$f" ]; then
+                echo "  - $(sha256sum \"$f\")"
+              fi
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE HARDEN END

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,4 @@
-# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE ASSERT BEGIN
+# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE VERIFY BEGIN
 name: Smoke
 
 on:
@@ -29,7 +29,7 @@ jobs:
           java-version: "8"
           cache: gradle
 
-      - name: Show Java version
+      - name: Show Java version (expect 1.8)
         run: |
           set -eux
           java -version
@@ -37,16 +37,33 @@ jobs:
       - name: Gradle wrapper permissions
         run: chmod +x ./gradlew
 
-      - name: Gradle version (expect 6.9.4) and assert
+      - name: Show pinned gradle.properties (if any)
         run: |
           set -eux
-          ./gradlew -Dorg.gradle.java.home="$JAVA_HOME" -v | tee gradle-version.txt
-          echo "---- Raw gradle -v ----"
-          cat gradle-version.txt
+          if [ -f gradle.properties ]; then
+            echo "----- gradle.properties -----"
+            sed -n '1,200p' gradle.properties | sed 's/./&/g' | cat
+            echo "-----------------------------"
+          else
+            echo "No root gradle.properties found."
+          fi
+
+      - name: Create CI init script to print JVMs and properties
+        run: |
+          cat > ci-init.gradle <<'EOF'
+          println "[CI] env JAVA_HOME=" + System.getenv("JAVA_HOME")
+          println "[CI] sysprop org.gradle.java.home=" + System.getProperty("org.gradle.java.home")
+          println "[CI] sysprop java.home=" + System.getProperty("java.home")
+          EOF
+
+      - name: Gradle version (expect 6.9.4) with CI Java override
+        run: |
+          set -eux
+          ./gradlew -I ci-init.gradle -Dorg.gradle.java.home="$JAVA_HOME" -v | tee gradle-version.txt
           echo "---- Asserting Gradle 6.9.4 ----"
           grep -E "^Gradle 6\.9\.4$" gradle-version.txt
 
-      - name: Smoke (deterministic)
+      - name: Smoke (deterministic) with CI Java override
         run: ./gradlew -Dorg.gradle.java.home="$JAVA_HOME" :mapper-cli:smoke --no-daemon -Dorg.gradle.jvmargs="-Xmx2g"
 
       - name: Show hashes
@@ -69,6 +86,7 @@ jobs:
         with:
           name: smoke-artifacts
           path: |
+            ci-init.gradle
             gradle-version.txt
             mapper-cli/build/smoke/m1.tiny
             mapper-cli/build/smoke/m2.tiny
@@ -80,4 +98,4 @@ jobs:
             mapper-cli/build/smoke/remap-asm-b.jar
             mapper-cli/build/smoke/metrics1.json
             mapper-cli/build/smoke/metrics2.json
-# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE ASSERT END
+# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE VERIFY END


### PR DESCRIPTION
This PR hardens the Smoke workflow:

- Always use Temurin JDK 8
- Prove -Dorg.gradle.java.home override via ci-init prints
- Assert wrapper distributionUrl contains 6.9.4
- Add step summary and 7-day artifact retention

Deterministic, workflow-only change.

# >>> AUTOGEN: BYTECODEMAPPER CI GHA SMOKE HARDEN BEGIN/END